### PR TITLE
timeout messages in the broker

### DIFF
--- a/src/AMQPRPCClient.js
+++ b/src/AMQPRPCClient.js
@@ -17,7 +17,7 @@ class AMQPRPCClient extends AMQPEndpoint {
    * @param {String} params.requestsQueue queue for sending commands, should correspond with AMQPRPCServer
    * @param {String} [params.repliesQueue=''] queue for feedback from AMQPRPCServer,
    *    default is '' which means auto-generated queue name
-   * @param {Number} [params.timeout=60000] Timeout for cases when server is not responding
+   * @param {Number} [params.timeout=60000] Timeout for cases when server is not responding or too busy.
    * @param {Object} [params.defaultMessageOptions] additional options for publishing the request to the queue
    */
   constructor(connection, params = {}) {
@@ -52,7 +52,7 @@ class AMQPRPCClient extends AMQPEndpoint {
     const replyTo = this._repliesQueue;
     const timeout = this._params.timeout;
     const requestsQueue = this._params.requestsQueue;
-    const commonProperties = { replyTo, correlationId };
+    const commonProperties = { replyTo, correlationId, expiration: timeout };
 
     const properties = Object.assign({},
             messageOptions,

--- a/test/unit/AMQPRPCClient.test.js
+++ b/test/unit/AMQPRPCClient.test.js
@@ -63,7 +63,7 @@ describe('AMQPRPCClient', () => {
       expect(channelStub.sendToQueue).to.have.been.calledOnce.and
         .calledWith('q',
           new Command('test').pack(),
-          { correlationId: "0", replyTo: "r", userId: 'john.doe' }
+          { correlationId: "0", replyTo: "r", userId: 'john.doe', expiration: 60000 }
         );
     });
 
@@ -73,7 +73,7 @@ describe('AMQPRPCClient', () => {
       expect(channelStub.sendToQueue).to.have.been.calledOnce.and
         .calledWith('q',
           new Command('test', [1, 'foo']).pack(),
-          { correlationId: "0", replyTo: "r", userId: 'john.doe' }
+          { correlationId: "0", replyTo: "r", userId: 'john.doe', expiration: 60000 }
         );
     });
 
@@ -83,7 +83,7 @@ describe('AMQPRPCClient', () => {
       expect(channelStub.sendToQueue).to.have.been.calledOnce.and
         .calledWith('q',
           new Command('test', [1, 'foo']).pack(),
-          { correlationId: "0", replyTo: "r", persistent: false, userId: 'john.doe' }
+          { correlationId: "0", replyTo: "r", persistent: false, userId: 'john.doe', expiration: 60000 }
         );
     });
 


### PR DESCRIPTION
My thought process is: if the workers are too busy handling requests and the client timeouts a request, I'd expect the broker to timeout the message and not even process it.

Otherwise we can get into the situation that the workers are too busy processing jobs that the clients have discarded.