### PR TITLE
allow configuring the prefetch count

### DIFF
--- a/src/AMQPRPCServer.js
+++ b/src/AMQPRPCServer.js
@@ -16,6 +16,8 @@ class AMQPRPCServer extends AMQPEndpoint {
    * @param {Object} params
    * @param {String} params.requestsQueue queue when AMQPRPC client sends commands, should correspond with AMQPRPCClient
    *    default is '' which means auto-generated queue name
+   * @param {String} params.prefetchCount specifies the number of commands that should be run in parallel
+   *    default is 0 which means unlimited
    */
   constructor(connection, params = {}) {
     params.requestsQueue = params.requestsQueue || '';
@@ -24,6 +26,7 @@ class AMQPRPCServer extends AMQPEndpoint {
 
     this._requestsQueue = params.requestsQueue;
     this._commands = {};
+    this._prefetchCount = params.prefetchCount || 0;
   }
 
   /**
@@ -37,8 +40,12 @@ class AMQPRPCServer extends AMQPEndpoint {
 
 
     if (this._requestsQueue === '') {
-      const response = await this._channel.assertQueue('', {exclusive: true});
+      const response = await this._channel.assertQueue('', { exclusive: true });
       this._requestsQueue = response.queue;
+    }
+
+    if (this._channel.prefetch && this._prefetchCount !== 0) {
+      await this._channel.prefetch(this._prefetchCount);
     }
 
     const consumeResult = await this._channel.consume(this._requestsQueue, (msg) => this._handleMsg(msg));
@@ -80,20 +87,21 @@ class AMQPRPCServer extends AMQPEndpoint {
    */
   async _handleMsg(msg) {
 
-    this._channel.ack(msg);
     const replyTo = msg.properties.replyTo;
     const correlationId = msg.properties.correlationId;
     const persistent = msg.properties.deliveryMode !== 1;
 
     try {
       const result = await this._dispatchCommand(msg);
-
       const content = new CommandResult(CommandResult.STATES.SUCCESS, result).pack();
-      this._channel.sendToQueue(replyTo, content, {correlationId, persistent});
-
+      await this._channel.sendToQueue(replyTo, content, {correlationId, persistent});
+      await this._channel.ack(msg);
     } catch (error) {
-      const content = new CommandResult(CommandResult.STATES.ERROR, error).pack();
-      this._channel.sendToQueue(replyTo, content, {correlationId, persistent});
+      if (this._channel) {
+        const content = new CommandResult(CommandResult.STATES.ERROR, error).pack();
+        await this._channel.sendToQueue(replyTo, content, {correlationId, persistent});
+        await this._channel.reject(msg);
+      }
     }
   }
 

--- a/test/integration/parallelism.test.js
+++ b/test/integration/parallelism.test.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const chai = require('chai');
+const chaiAsPromised = require("chai-as-promised");
+chai.use(chaiAsPromised);
+const {expect} = chai;
+
+const {AMQPRPCClient, AMQPRPCServer} = require('../..');
+const helpers = require('../helpers.js');
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+
+describe('AMQPServer with prefetchCount = 1', () => {
+  let connection;
+  let client;
+  let server;
+
+  beforeEach(async () => {
+    connection = await helpers.getAmqpConnection();
+    server = new AMQPRPCServer(connection, { prefetchCount: 1 });
+    await server.start();
+    client = new AMQPRPCClient(connection, { requestsQueue: server.requestsQueue, timeout: 200 });
+    await client.start();
+  });
+
+  afterEach(async () => {
+    await server.disconnect();
+    await client.disconnect();
+    await helpers.closeAmqpConnection();
+  });
+
+  describe('when client send multiples command before finishing', () => {
+    it('should process one command at the time', async () => {
+      const results = [];
+      let times = 0;
+      server.addCommand('command', async () => {
+        const i = times++;
+        if (i === 0) {
+          // first message is slower;
+          await sleep(40);
+        }
+        results.push(i);
+      });
+
+      await Promise.all([
+          client.sendCommand('command'),
+          client.sendCommand('command')
+      ]);
+
+      expect(results).to.deep.equal([0, 1]);
+    });
+  });
+});


### PR DESCRIPTION
This is a major change, the current behavior is to ACK a message as soon as is received. 

I am proposing instead to ACK the message once is processed. With the `prefetch` parameter unset, this almost the same than the current behavior.. rabbitmq will report that the messages are not acked yet but it will keep delivering messages as before.

But this allow us to configure the prefetch count which is very useful. Let's say we know our worker can't handle more than 5 operations at the time, with this change you can initialize the server as:

```javascript
const server = new AMQPRPCServer(connection, { prefetchCount: 5 });
```

More info about prefetch [here](https://www.rabbitmq.com/consumer-prefetch.html).

In addition to this I am using `reject` if the command fail, this is an ack the message but mark it as rejected and does not re-queues it. This is helpful when you are looking at rabbitmq metrics for example.